### PR TITLE
Set correct content scale on image contexts

### DIFF
--- a/Sources/TouchDrawView.swift
+++ b/Sources/TouchDrawView.swift
@@ -115,7 +115,7 @@ open class TouchDrawView: UIView {
     
     /// merges tempImageView into mainImageView
     fileprivate func mergeViews() {
-        UIGraphicsBeginImageContext(self.mainImageView.frame.size)
+        UIGraphicsBeginImageContextWithOptions(self.mainImageView.frame.size, false, UIScreen.main.scale)
         self.mainImageView.image?.draw(in: self.mainImageView.frame, blendMode: CGBlendMode.normal, alpha: 1.0)
         self.tempImageView.image?.draw(in: self.tempImageView.frame, blendMode: CGBlendMode.normal, alpha: self.brushProperties.color.alpha)
         
@@ -177,7 +177,7 @@ open class TouchDrawView: UIView {
     /// draws a line from one point to another with certain properties
     fileprivate func drawLineFrom(_ fromPoint: CGPoint, toPoint: CGPoint, properties: StrokeSettings) -> Void {
         
-        UIGraphicsBeginImageContext(self.frame.size)
+        UIGraphicsBeginImageContextWithOptions(self.frame.size, false, UIScreen.main.scale)
         let context = UIGraphicsGetCurrentContext()
         
         context!.move(to: CGPoint(x: fromPoint.x, y: fromPoint.y))
@@ -199,7 +199,7 @@ open class TouchDrawView: UIView {
     
     /// exports the current drawing
     open func exportDrawing() -> UIImage {
-        UIGraphicsBeginImageContext(self.mainImageView.bounds.size)
+        UIGraphicsBeginImageContextWithOptions(self.mainImageView.bounds.size, false, UIScreen.main.scale)
         self.mainImageView.image?.draw(in: self.mainImageView.frame)
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()


### PR DESCRIPTION
When using `UIGraphicsBeginImageContext`, the scale is always set to one, causing the rendered images to look poor on retina devices. This change supplies the correct device scale when setting up the image contexts.