### PR TITLE
Add public access modifier to initializers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ xcode_scheme: TouchDraw
 # Specify the last iOS sdk
 xcode_sdk: iphonesimulator
 
-script: set -o pipefail && xcodebuild -workspace $TRAVIS_XCODE_WORKSPACE -scheme $TRAVIS_XCODE_SCHEME -sdk $TRAVIS_XCODE_SDK -destination 'name=iPhone 6' build test | xcpretty
+script: set -o pipefail && xcodebuild -workspace $TRAVIS_XCODE_WORKSPACE -scheme $TRAVIS_XCODE_SCHEME -sdk $TRAVIS_XCODE_SDK -destination 'OS=10.1,name=iPhone 6' build test | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: objective-c
 
 # Xcode version
-osx_image: xcode8.1sneakpeek
+osx_image: xcode8.2
 
 # Specify the opening file for the project
 xcode_workspace: TouchDraw.xcworkspace

--- a/Sources/Stroke.swift
+++ b/Sources/Stroke.swift
@@ -16,14 +16,14 @@ open class Stroke: NSObject, NSCoding {
     internal var settings: StrokeSettings!
 
     /// default initialization
-    override init() {
+    override public init() {
         super.init()
         self.points = [];
         self.settings = StrokeSettings()
     }
 
     /// initialize a stroke with ceertain points and stroke settings
-    init(points: [String], settings: StrokeSettings) {
+    public init(points: [String], settings: StrokeSettings) {
         super.init()
         self.points = points
         self.settings = settings

--- a/Sources/StrokeSettings.swift
+++ b/Sources/StrokeSettings.swift
@@ -21,14 +21,14 @@ open class StrokeSettings: NSObject, NSCoding {
     }
 
     /// initializes a StrokeSettings with another StrokeSettings object
-    init(settings: StrokeSettings) {
+    public init(settings: StrokeSettings) {
         super.init()
         self.color = settings.color
         self.width = settings.width
     }
 
     /// initializes a StrokeSettings with a color and width
-    init(color: CIColor, width: CGFloat) {
+    public init(color: CIColor, width: CGFloat) {
         super.init()
         self.color = color
         self.width = width

--- a/Sources/TouchDrawView.swift
+++ b/Sources/TouchDrawView.swift
@@ -54,7 +54,7 @@ open class TouchDrawView: UIView {
     fileprivate var clearEnabled = false
 
     /// initializes a TouchDrawView instance
-    override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
         self.initTouchDrawView(frame)
     }

--- a/TouchDraw.xcodeproj/project.pbxproj
+++ b/TouchDraw.xcodeproj/project.pbxproj
@@ -247,7 +247,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.dehli.TouchDrawTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -260,7 +260,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.dehli.TouchDrawTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -375,7 +375,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -395,7 +395,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.dehli.TouchDraw;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
With TouchDraw installed through CocoaPods, when trying to create a TouchDrawView through code (`let v = TouchDrawView(frame: CGRect.zero)`), Xcode reported this error:

```
'TouchDrawView' initializer is inaccessible due to 'internal' protection level
```

This PR adds public access to all initializers that were internal.