### PR TITLE
Added originalImage that will persist as the image under the strokes.

### DIFF
--- a/Sources/TouchDrawView.swift
+++ b/Sources/TouchDrawView.swift
@@ -35,6 +35,9 @@ open class TouchDrawView: UIImageView {
     /// Used to register undo and redo actions
     fileprivate let touchDrawUndoManager = UndoManager()
 
+    /// Used to keep track of the original image
+    internal var originalImage : UIImage?
+
     /// Used to keep track of all the strokes
     internal var stack: [Stroke] = []
 
@@ -235,6 +238,15 @@ extension TouchDrawView {
 
 // MARK: - Drawing
 
+extension TouchDrawView {
+    
+    /// Sets the input image as the original image. This image is under the strokes
+    public func setOriginalImage(image: UIImage?){
+        originalImage = image
+        redrawStack()
+    }
+}
+
 fileprivate extension TouchDrawView {
 
     /// Begins the image context
@@ -253,9 +265,10 @@ fileprivate extension TouchDrawView {
         image?.draw(in: bounds)
     }
 
-    /// Clears view, then draws stack
+    /// Clears view except for original image, then draws stack
     func redrawStack() {
         beginImageContext()
+        originalImage?.draw(in: bounds)
         for stroke in stack {
             drawStroke(stroke)
         }


### PR DESCRIPTION
This feature should be a solution to issue #34 

Use setOriginalImage to set an image that will be placed under all strokes.

The image will persist undos and clears and redraws.

To remove the image, call setOriginalImage with a nil param