### PR TITLE
Fix export drawing for cases where the origin of the frame was not .zero

### DIFF
--- a/Sources/TouchDrawView.swift
+++ b/Sources/TouchDrawView.swift
@@ -102,7 +102,7 @@ open class TouchDrawView: UIView {
     /// Exports the current drawing
     open func exportDrawing() -> UIImage {
         UIGraphicsBeginImageContextWithOptions(imageView.bounds.size, false, UIScreen.main.scale)
-        imageView.image?.draw(in: imageView.frame)
+        imageView.image?.draw(in: imageView.bounds)
 
         let imageFromContext = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
@@ -271,7 +271,7 @@ fileprivate extension TouchDrawView {
 
     /// Begins the image context
     func beginImageContext() {
-        UIGraphicsBeginImageContextWithOptions(imageView.frame.size, false, UIScreen.main.scale)
+        UIGraphicsBeginImageContextWithOptions(imageView.bounds.size, false, UIScreen.main.scale)
     }
 
     /// Ends image context and sets UIImage to what was on the context


### PR DESCRIPTION
As @starduskWK mentioned in #41 , we get a wrong `UIImage` export when the frame origin is not `.zero`.