### PR TITLE
Prevent drop down to dismiss gesture in modal presentations (iOS 13)

### DIFF
--- a/Sources/TouchDrawView.swift
+++ b/Sources/TouchDrawView.swift
@@ -221,6 +221,15 @@ open class TouchDrawView: UIView {
 
 extension TouchDrawView {
 
+    open override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        // This prevents the drop down to dismiss gesture in modal presentations from iOS 13 on.
+        // See also: https://stackoverflow.com/questions/56718552/disable-gesture-to-pull-down-form-page-sheet-modal-presentation
+        if gestureRecognizer is UIPanGestureRecognizer {
+            return false
+        }
+        return true
+    }
+    
     /// Triggered when touches begin
     override open func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         if let touch = touches.first {

--- a/Sources/TouchDrawView.swift
+++ b/Sources/TouchDrawView.swift
@@ -102,7 +102,7 @@ open class TouchDrawView: UIView {
     /// Exports the current drawing
     open func exportDrawing() -> UIImage {
         UIGraphicsBeginImageContextWithOptions(imageView.bounds.size, false, UIScreen.main.scale)
-        imageView.image?.draw(in: imageView.frame)
+        imageView.image?.draw(in: imageView.bounds)
 
         let imageFromContext = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
@@ -271,7 +271,7 @@ fileprivate extension TouchDrawView {
 
     /// Begins the image context
     func beginImageContext() {
-        UIGraphicsBeginImageContextWithOptions(imageView.frame.size, false, UIScreen.main.scale)
+        UIGraphicsBeginImageContextWithOptions(imageView.bounds.size, false, UIScreen.main.scale)
     }
 
     /// Ends image context and sets UIImage to what was on the context


### PR DESCRIPTION
When TouchDrawView is embedded in a modal presentation in iOS 13, the user can drag to dismiss. This interferes with the drawing.

This PR fixes that like in the accepted answer here (method #3): https://stackoverflow.com/a/57635168/4846592